### PR TITLE
Add options to gathering.

### DIFF
--- a/src/clojure/snow_hall/core.clj
+++ b/src/clojure/snow_hall/core.clj
@@ -109,7 +109,7 @@
   [handle dev]
   (fn []
     (tear-down-stack dev)
-    (shutdown-agents)
+    ;; (shutdown-agents) Do not shutdown pools as we cannot restart them in REPL
     (handle)))
 
 (defn start-server

--- a/src/clojure/snow_hall/core.clj
+++ b/src/clojure/snow_hall/core.clj
@@ -29,10 +29,6 @@
 (defn create-game-store
   []
   (-> (game-mgr/create-store)
-      (game-mgr/add-game
-       {:name "Code4Life"
-        :java "code4life.Referee"
-        :player-count 2})
       (game-mgr/add-game snow-hall.games.library.sample/game-definition)
       (game-mgr/add-game snow-hall.games.library.tic-tac-toe/game-definition)
       (game-mgr/add-game snow-hall.games.library.rpsls/game-definition)

--- a/src/clojure/snow_hall/games/game.clj
+++ b/src/clojure/snow_hall/games/game.clj
@@ -1,20 +1,33 @@
 (ns snow-hall.games.game)
 
-(defprotocol GameFactory
+(defprotocol Game
   "Abstraction of a game"
-  (create-engine [factory] "Creates a new round engine for this game.
-  c is the number of players participating the round.
-  Returns a Round."))
+  (get-specs
+   [game]
+   "Gets the specs of the game")
+  (read-options 
+   [game options]
+   "Reads user options to create options specific to this game")
+  (get-player-count
+   [game options]
+   "Gets the number of players participating to this game")
+  (create-engine 
+   [game options] 
+   "Creates a new round engine for this game.
+   c is the number of players participating the round.
+   Returns a Round."))
+
+(defn get-name
+  "Gets the name of the game."
+  [game]
+  (-> game (get-specs) (:name)))
+
+(defn get-player-range
+  [game]
+  {:post [(some? %)]}
+  (-> game (get-specs)( :players)))
 
 (defprotocol RoundEngine
   (ios [e] "Returns the arrays of IOs for each player in the Round.
   Each IO is made of :in chan for player move and :out chan for Round messages." )
   (stop [e] "Stops the round."))
-
-(defn sanitize-options
-  [game options]
-  (throw (UnsupportedOperationException.)))
-
-(defn get-player-count
-  [game options]
-  (throw (UnsupportedOperationException.)))

--- a/src/clojure/snow_hall/games/game.clj
+++ b/src/clojure/snow_hall/games/game.clj
@@ -25,7 +25,7 @@
 (defn get-player-range
   [game]
   {:post [(some? %)]}
-  (-> game (get-specs)( :players)))
+  (-> game (get-specs)( :player-count)))
 
 (defprotocol RoundEngine
   (ios [e] "Returns the arrays of IOs for each player in the Round.

--- a/src/clojure/snow_hall/games/game.clj
+++ b/src/clojure/snow_hall/games/game.clj
@@ -10,3 +10,11 @@
   (ios [e] "Returns the arrays of IOs for each player in the Round.
   Each IO is made of :in chan for player move and :out chan for Round messages." )
   (stop [e] "Stops the round."))
+
+(defn sanitize-options
+  [game options]
+  (throw (UnsupportedOperationException.)))
+
+(defn get-player-count
+  [game options]
+  (throw (UnsupportedOperationException.)))

--- a/src/clojure/snow_hall/games/library/rpsls.clj
+++ b/src/clojure/snow_hall/games/library/rpsls.clj
@@ -53,7 +53,6 @@
 
 (defn win?
   [{:keys [win-score scores]} player]
-  (println (str player " -> " win-score " <> " scores))
   (= (get scores player) win-score))
 
 (defn set-sign-in-state

--- a/src/clojure/snow_hall/games/library/rpsls.clj
+++ b/src/clojure/snow_hall/games/library/rpsls.clj
@@ -245,10 +245,11 @@
   (reify
     game/Game
     (get-specs [this] {:name "Rock Paper Scissors Lizard Spock"
-                       :players {:exact 2}})
+                       :player-count {:exact 2}})
     (read-options 
-      [this options] 
-      {:win-score (get options "a" 5)})
+      [this options]
+     (println (str "opts " options)) 
+      {:win-score (get options "win-score" 5)})
     (get-player-count [this options] 2)
     (create-engine [this options] (create-and-start options))))
 

--- a/src/clojure/snow_hall/games/library/rpsls.clj
+++ b/src/clojure/snow_hall/games/library/rpsls.clj
@@ -1,6 +1,6 @@
 (ns snow-hall.games.library.rpsls
   (:require [clojure.core.async :as async :refer [chan go alts!! >!! close!]]
-            [snow-hall.games.game :refer [GameFactory RoundEngine]]))
+            [snow-hall.games.game :as game]))
 
 (def win-matrix
   {:rock #{:scissors :lizard}
@@ -27,7 +27,7 @@
   {:in (chan 1) :out (chan 1)})
 
 (defrecord RpclsRound [ios stop state]
-  RoundEngine
+  game/RoundEngine
   (ios [e] ios)
   (stop [e] (async/offer! stop true)))
 
@@ -38,8 +38,9 @@
   {:p1 0 :p2 0})
 
 (defn create-state
-  []
+  [{:keys [win-score]}]
   {:scores (create-scoreboard)
+   :win-score win-score
    :last-signs nil
    :signs {}
    :status :created
@@ -47,16 +48,12 @@
    :messages nil})
 
 (defn state->str
-  [{:keys [scores last-signs]}]
-  (str (:p1 scores) "|" (:p2 scores) ";" (some-> last-signs :p1 name) "|" (some-> last-signs :p2 name)))
+  [{:keys [scores last-signs win-score]}]
+  (str (:p1 scores) "/" win-score "|" (:p2 scores) "/" win-score ";" (some-> last-signs :p1 name) "|" (some-> last-signs :p2 name)))
 
-(def win-score 5)
 (defn win?
-  [scoreboard i]
-  (let [score  (case i
-                 0 (:p1 scoreboard)
-                 1 (:p2 scoreboard))]
-    (= score win-score)))
+  [{:keys [win-score scoreboard]} player]
+  (= (get scoreboard player) win-score))
 
 (defn set-sign-in-state
   [state player-idx sign]
@@ -85,10 +82,10 @@
          :last-signs signs))
 
 (defn find-winner
-  [{:keys [scores]}]
+  [state]
   (cond
-    (win? scores 0) :p1
-    (win? scores 1) :p2))
+    (win? state :p1) :p1
+    (win? state :p2) :p2))
 
 (defn check-for-victory
   [state]
@@ -226,33 +223,38 @@
             (publish-completion! round next-state)
             (recur)))))))
 
+(defn- create
+  [options]
+  (RpclsRound.
+   (repeatedly 2 create-io)
+   (chan 1)
+   (atom (create-state options))))
+
 (defn- start
   [round]
   (mark-round-as-started! round)
   (go (run-loop! round)))
 
-(defn- create
-  []
-  (RpclsRound.
-   (repeatedly 2 create-io)
-   (chan 1)
-   (atom (create-state))))
-
-(def game-factory
-  (reify
-    GameFactory
-    (create-engine [f]
-      (let [round (create)]
-        (start round)
-        round))))
+(defn create-and-start
+  [options]
+  (let [round (create options)]
+    (start round)
+    round))
 
 (def game-definition
-  {:name "Rock Paper Scissors Lizard Spock"
-   :player-count 2
-   :factory game-factory})
+  (reify
+    game/Game
+    (get-specs [this] {:name "Rock Paper Scissors Lizard Spock"
+                       :players {:exact 2}})
+    (read-options 
+      [this options] 
+      {:win-score (get options "a" 5)})
+    (get-player-count [this options] 2)
+    (create-engine [this options] (create-and-start options))))
 
 (comment
-  (def round (snow-hall.games.game/create-engine game-factory))
+  (def win-score 5)
+  (def round (snow-hall.games.game/create-engine game-definition {:win-score win-score}))
   round
   (snow-hall.games.game/stop round)
 

--- a/src/clojure/snow_hall/games/library/rpsls.clj
+++ b/src/clojure/snow_hall/games/library/rpsls.clj
@@ -52,8 +52,9 @@
   (str (:p1 scores) "/" win-score "|" (:p2 scores) "/" win-score ";" (some-> last-signs :p1 name) "|" (some-> last-signs :p2 name)))
 
 (defn win?
-  [{:keys [win-score scoreboard]} player]
-  (= (get scoreboard player) win-score))
+  [{:keys [win-score scores]} player]
+  (println (str player " -> " win-score " <> " scores))
+  (= (get scores player) win-score))
 
 (defn set-sign-in-state
   [state player-idx sign]
@@ -247,9 +248,8 @@
     (get-specs [this] {:name "Rock Paper Scissors Lizard Spock"
                        :player-count {:exact 2}})
     (read-options 
-      [this options]
-     (println (str "opts " options)) 
-      {:win-score (get options "win-score" 5)})
+     [this options] 
+     {:win-score (get options "win-score" 5)})
     (get-player-count [this options] 2)
     (create-engine [this options] (create-and-start options))))
 

--- a/src/clojure/snow_hall/games/library/sample.clj
+++ b/src/clojure/snow_hall/games/library/sample.clj
@@ -44,6 +44,7 @@
   (reify
     game/Game
     (get-specs [this] {:name "Sample"
-                      :players {:exact 2}})
+                      :player-count {:exact 2}})
+    (read-options [this options] {})
     (get-player-count [this option] 2)
     (create-engine [this options] (create-and-start))))

--- a/src/clojure/snow_hall/games/library/tic_tac_toe.clj
+++ b/src/clojure/snow_hall/games/library/tic_tac_toe.clj
@@ -173,7 +173,7 @@
   (reify
     game/Game
     (get-specs [this] {:name "Tic Tac Toe"
-                      :players {:exact 2}})
+                      :player-count {:exact 2}})
     (read-options [this options] nil)
     (get-player-count [this options] 2)
     (create-engine [this options] (create-and-start))))

--- a/src/clojure/snow_hall/games/library/tic_tac_toe.clj
+++ b/src/clojure/snow_hall/games/library/tic_tac_toe.clj
@@ -1,6 +1,6 @@
 (ns snow-hall.games.library.tic-tac-toe
   (:require [clojure.core.async :as async :refer [chan go-loop alts! >! close!]]
-            [snow-hall.games.game :refer [GameFactory RoundEngine]]))
+            [snow-hall.games.game :as game]))
 
 (def player-symbols
   {0 "X"
@@ -107,7 +107,7 @@
   {:in (chan 1) :out (chan 1)})
 
 (defrecord TicTacToeRound [ios stop]
-  RoundEngine
+  game/RoundEngine
   (ios [e] ios)
   (stop [e] (async/offer! stop true)))
 
@@ -117,6 +117,12 @@
        (get-positions)
        (map #(or % "-"))
        (apply str)))
+
+(defn- create
+  []
+  (TicTacToeRound.
+   (repeatedly 2 create-io)
+   (chan 1)))
 
 (defn- start
   [{:keys [ios stop]}]
@@ -157,35 +163,29 @@
           (close! (:out io))
           (close! (:in io)))))))
 
-(defn- create
+(defn create-and-start
   []
-  (TicTacToeRound.
-   (repeatedly 2 create-io)
-   (chan 1)))
-
-(def game-factory
-  (reify
-    GameFactory
-    (create-engine [f]
-      (let [round (create)]
-        (start round)
-        round))))
+  (let [round (create)]
+    (start round)
+    round))
 
 (def game-definition
-  {:name "Tic Tac Toe"
-   :player-count 2
-   :factory game-factory})
+  (reify
+    game/Game
+    (get-specs [this] {:name "Tic Tac Toe"
+                      :players {:exact 2}})
+    (read-options [this options] nil)
+    (get-player-count [this options] 2)
+    (create-engine [this options] (create-and-start))))
 
 (comment
-  (def round (snow-hall.games.game/create-engine game-factory))
+  (def round (game/create-engine game-definition nil))
   round
   (def in1 ((comp :in first :ios) round))
   (def out1 ((comp :out first :ios) round))
   (def in2 ((comp :in second :ios) round))
   (def out2 ((comp :out second :ios) round))
-  (clojure.core.async/go (while true
-                           (do (println (str "p1 -> " (clojure.core.async/<! out1)))
-                               (println (str "p2 -> " (clojure.core.async/<! out2))))))
+  
   (clojure.core.async/offer! in1 [0 0])
   (clojure.core.async/offer! in2 [0 1])
   (clojure.core.async/offer! in1 [1 0])

--- a/src/clojure/snow_hall/games/manager.clj
+++ b/src/clojure/snow_hall/games/manager.clj
@@ -1,14 +1,14 @@
 (ns snow-hall.games.manager
   (:require [clojure.spec.alpha :as s]
-            [snow-hall.validate :refer [create-validation]]))
+            [snow-hall.validate :refer [create-validation]]
+            [snow-hall.games.game :as game]))
 
 ; Specs
 
 (s/def ::name string?)
 (s/def ::player-count int?)
 (s/def ::java string?)
-(s/def ::game (s/keys :req-un [::name ::player-count]
-                      :opt-un [::java]))
+(s/def ::game some?)
 (s/def ::games (s/map-of ::name ::game))
 
 ; methods
@@ -22,7 +22,7 @@
 (defn add-game
   "Adds a new game to the server"
   [store game]
-  (assoc store (:name game) game))
+  (assoc store (game/get-name game) game))
 
 (defn list-games
   "Lists all games available in this server"

--- a/src/clojure/snow_hall/games/round.clj
+++ b/src/clojure/snow_hall/games/round.clj
@@ -89,10 +89,10 @@
 
 (defn create-round
   [gathering game]
-  {:pre [(= (:game gathering) (:name game))]}
+  {:pre [(= (:game gathering) (game/get-name game))]}
   (let [player-uuids (:players gathering)
         a-state (create-state-agent player-uuids) 
-        engine (game/create-engine (:factory game))]
+        engine (game/create-engine game (:options gathering))]
     (bind-engine a-state player-uuids engine)
     {:ruid (uuids/random-uuid)
      :game (:game gathering)
@@ -126,10 +126,9 @@
   (def u1 (first us))
   (def u2 (second us))
   (def game sg/game-definition)
-  (:factory game)
-  (def gath {:players us :game (:name game)})
+  (def gath {:players us :game (game/get-name game)})
   ; create the round
-  (def r1 (create-round gath sg/game-definition))
+  (def r1 (create-round gath game))
   (:engine r1)
   (play-round r1 u2 "IDLE")
   (play-round r1 u1 "MOVE 1")

--- a/src/clojure/snow_hall/hall/butler.clj
+++ b/src/clojure/snow_hall/hall/butler.clj
@@ -1,8 +1,8 @@
 (ns snow-hall.hall.butler
-  (:require
-   [clojure.spec.alpha :as s]
-   [snow-hall.uuid :as uuids]
-   [snow-hall.validate :refer [create-validation]]))
+  (:require    [clojure.spec.alpha :as s]
+               [snow-hall.uuid :as uuids]
+               [snow-hall.validate :refer [create-validation]]
+               [snow-hall.games.game :as games]))
 
 (s/def ::id string?)
 (s/def ::token uuids/uuid?)
@@ -30,18 +30,22 @@
 (defn create-player-list
   [player-count first-player]
   (reduce
-    (fn [acc _] (conj acc {:token (uuids/random-uuid)}))
-    [(:uuid first-player)]
-    (range (dec player-count))))
+   (fn [acc _] (conj acc {:token (uuids/random-uuid)}))
+   [(:uuid first-player)]
+   (range (dec player-count))))
 
 (defn create-gathering
   "Creates a new game for a user"
-  [{:keys [tab user game]}]
+  [{:keys [tab user game options]}]
+  ; TODO we must use the options to find the player count
   (let [game-id (generate-id tab)
-        players (create-player-list (:player-count game) user)]
+        clean-options (games/sanitize-options game options)
+        player-count (games/get-player-count game options)
+        players (create-player-list player-count user)]
     {:id game-id
      :game (:name game)
-     :players players}))
+     :players players
+     :options clean-options}))
 
 (defn register-gathering
   "Registers a new gathering to the tab."

--- a/src/clojure/snow_hall/hall/butler.clj
+++ b/src/clojure/snow_hall/hall/butler.clj
@@ -36,16 +36,16 @@
 
 (defn create-gathering
   "Creates a new game for a user"
-  [{:keys [tab user game options]}]
+  [{:keys [tab user game user-options]}]
   ; TODO we must use the options to find the player count
   (let [game-id (generate-id tab)
-        clean-options (games/sanitize-options game options)
-        player-count (games/get-player-count game options)
+        game-options (games/read-options game user-options)
+        player-count (games/get-player-count game game-options)
         players (create-player-list player-count user)]
     {:id game-id
-     :game (:name game)
+     :game (games/get-name game)
      :players players
-     :options clean-options}))
+     :options game-options}))
 
 (defn register-gathering
   "Registers a new gathering to the tab."

--- a/src/clojure/snow_hall/hall/butler.clj
+++ b/src/clojure/snow_hall/hall/butler.clj
@@ -37,7 +37,6 @@
 (defn create-gathering
   "Creates a new game for a user"
   [{:keys [tab user game user-options]}]
-  ; TODO we must use the options to find the player count
   (let [game-id (generate-id tab)
         game-options (games/read-options game user-options)
         player-count (games/get-player-count game game-options)

--- a/src/clojure/snow_hall/rest/games.clj
+++ b/src/clojure/snow_hall/rest/games.clj
@@ -1,11 +1,13 @@
 (ns snow-hall.rest.games
   (:require [compojure.core :as http]
-            [snow-hall.games.manager :as mgr]))
+            [snow-hall.games.manager :as mgr]
+            [snow-hall.games.game :as game]))
 
-(defn game->json 
+(defn game->json
   "Exports a given game, dropping the unwanted attributes"
   [game]
-  (into {} (filter (comp #{:name :player-count} first) game)))
+  {:name (game/get-name game)
+   :player-count (game/get-player-range game)})
 
 (defn list-games-request [game-registry _req]
   (let [games (mgr/list-games @game-registry)
@@ -17,7 +19,3 @@
   [{:keys [games]}]
   [(http/context "/games" []
      (http/GET "/" [] (partial list-games-request games)))])
-
-(comment
-  (def some-game {:name "A" :player-count 1 :other "<hidden>"})
-  (game->json some-game))

--- a/src/clojure/snow_hall/rest/gatherings.clj
+++ b/src/clojure/snow_hall/rest/gatherings.clj
@@ -44,6 +44,10 @@
     (resolved gathering)
     (rejected {:status 404})))
 
+(defn with-options
+  [req & _]
+  (resolved (or (get-in req [:body "options"]) {})))
+
 (defn list-gathering-request
   [{:keys [tab]} _req]
   {:status 200
@@ -51,11 +55,12 @@
    :body (map format-gathering (vals @tab))})
 
 (defn do-create-gathering
-  [tab visitor game]
+  [tab visitor game options]
   (let [new-gathering (butler/create-gathering
                        {:tab @tab
                         :user visitor
-                        :game game})]
+                        :game game
+                        :options options})]
     (alter tab butler/register-gathering new-gathering)
     {:status 200
      :body new-gathering}))
@@ -64,10 +69,11 @@
   [{:keys [visitors tab games]} req]
   (with
    {:visitor (partial with-visitor @visitors req)
-    :game (partial with-game @games req)}
-   (fn [{:keys [visitor game]}]
+    :game (partial with-game @games req)
+    :options (partial with-options req)}
+   (fn [{:keys [visitor game options]}]
      (dosync 
-      (do-create-gathering tab visitor game)))))
+      (do-create-gathering tab visitor game options)))))
 
 (defn get-invit-list
   [gathering visitor]

--- a/src/clojure/snow_hall/rest/gatherings.clj
+++ b/src/clojure/snow_hall/rest/gatherings.clj
@@ -62,7 +62,6 @@
                         :game game
                         :user-options options})]
     (alter tab butler/register-gathering new-gathering)
-    (println (str "created: " new-gathering))
     {:status 200
      :body new-gathering}))
 

--- a/src/clojure/snow_hall/rest/gatherings.clj
+++ b/src/clojure/snow_hall/rest/gatherings.clj
@@ -45,7 +45,7 @@
     (rejected {:status 404})))
 
 (defn with-options
-  [req & _]
+  [req & _] 
   (resolved (or (get-in req [:body "options"]) {})))
 
 (defn list-gathering-request
@@ -60,8 +60,9 @@
                        {:tab @tab
                         :user visitor
                         :game game
-                        :options options})]
+                        :user-options options})]
     (alter tab butler/register-gathering new-gathering)
+    (println (str "created: " new-gathering))
     {:status 200
      :body new-gathering}))
 

--- a/test/clojure/integration/common.clj
+++ b/test/clojure/integration/common.clj
@@ -20,11 +20,12 @@
 
 (defn create-gathering
   "Creates a new gathering from a creator and registers the other players."
-  [{:keys [creator game-name others]}]
+  [{:keys [creator game-name others options]}]
   (let [gathering  (s/post
                     "/gatherings"
                     {"user" (authenticate creator)
-                     "game-id" game-name})
+                     "game-id" game-name
+                     "options" (or options {})})
         _ (is gathering)
         tokens (->> (gathering "players")
                     (map #(get % "token"))

--- a/test/clojure/integration/gatherings_test.clj
+++ b/test/clojure/integration/gatherings_test.clj
@@ -12,7 +12,7 @@
                   :guest u2)))
    (step "find games to play"
          (let [games (s/get "/games")
-               one-game (first (filter #(= 2 (%1 "player-count")) games))]
+               one-game (first (filter #(= 2 (get-in %1 ["player-count" "exact"])) games))]
            (is one-game)
            (swap! context assoc
                   :one-game one-game)))
@@ -23,7 +23,7 @@
                           {"user" {"uuid" (creator "uuid")
                                    "token" (creator "token")}
                            "game-id" (one-game "name")})]
-           (is gathering)
+           (is (some? gathering))
            (swap! context assoc :gathering gathering)))
    (step "finds invits"
          (let [{:keys [gathering creator]} @context

--- a/test/clojure/integration/play_rpsls_test.clj
+++ b/test/clojure/integration/play_rpsls_test.clj
@@ -51,7 +51,7 @@
                gathering (create-gathering {:creator creator
                                             :game-name "Rock Paper Scissors Lizard Spock"
                                             :others [guest]
-                                            :options {:target-score 3}})]
+                                            :options {"win-score" 3}})]
            (swap! context assoc :gathering gathering)))
    (step "start the game"
          (let [{:keys [gathering creator guest]} @context
@@ -62,14 +62,12 @@
            (wait-for-next-messages round-id guest 1)))
    (step "play one turn"
          (let [{:keys [round creator guest]} @context]
-           (play-and-check round {creator "rock" guest "paper"} "0|1;rock|paper")))
+           (play-and-check round {creator "rock" guest "paper"} "0/3|1/3;rock|paper")))
    (step "play to guest victory"
          (let [{:keys [round creator guest]} @context]
-          (play-and-check round {creator "rock" guest "rock"} "0|1;rock|rock")
-           (play-and-check round {creator "spock" guest "rock"} "1|1;spock|rock")
-           (play-and-check round {creator "spock" guest "paper"} "1|2;spock|paper")
-           (play-and-check round {creator "spock" guest "paper"} "1|3;spock|paper")
-           (play-and-check round {creator "spock" guest "paper"} "1|4;spock|paper")))
+           (play-and-check round {creator "rock" guest "rock"} "0/3|1/3;rock|rock")
+           (play-and-check round {creator "spock" guest "rock"} "1/3|1/3;spock|rock")
+           (play-and-check round {creator "spock" guest "paper"} "1/3|2/3;spock|paper")))
    (step "play victory move"
          (let [{:keys [round creator guest]} @context]
            (play round {creator "scissors" guest "spock"})))

--- a/test/clojure/integration/play_rpsls_test.clj
+++ b/test/clojure/integration/play_rpsls_test.clj
@@ -1,0 +1,85 @@
+(ns integration.play-rpsls-test
+  (:require [integration.story :as s :refer [story step]]
+            [integration.common :refer [authenticate
+                                        auth-header
+                                        create-visitors
+                                        create-gathering
+                                        start-round
+                                        consume-all-messages
+                                        wait-for-next-messages]]
+            [clojure.test :refer (is)]))
+
+(defn play
+  "Plays a round for Rock-Paper-Scissors."
+  [round moves]
+  (doseq [[player move] moves]
+    (consume-all-messages round player)
+    (s/post
+     (str "/rounds/" round "/messages")
+     {"user" (authenticate player)
+      "move" move})))
+
+(defn check
+  "Checks the output of a round of Rock-Paper-Scissors."
+  [round players result]
+  (doseq [player players]
+    (let [msgs (wait-for-next-messages round player 1)]
+      (is (= (map #(get % "content") msgs) (list result))))))
+
+(defn play-and-check
+  "Plays a round for Rock-Paper-Scissors and checks the output."
+  [round moves result]
+  (play round moves)
+  (check round (keys moves) result))
+
+(defn get-state
+  [round player]
+  (s/get
+   (str "/rounds/" round "/state")
+   {"Authorization" (auth-header player)}))
+
+(story
+ play-rock-paper-scissors-lizard-spock
+ (let [context (atom {})]
+   (step "create the users"
+         (let [[u1 & r] (create-visitors 5)]
+           (swap! context assoc
+                  :creator u1
+                  :guest (last r))))
+   (step "create the gathering"
+         (let [{:keys [creator guest]} @context
+               gathering (create-gathering {:creator creator
+                                            :game-name "Rock Paper Scissors Lizard Spock"
+                                            :others [guest]
+                                            :options {:target-score 3}})]
+           (swap! context assoc :gathering gathering)))
+   (step "start the game"
+         (let [{:keys [gathering creator guest]} @context
+               round (start-round gathering creator)
+               round-id (round "id")]
+           (swap! context assoc :round round-id)
+           (wait-for-next-messages round-id creator 1)
+           (wait-for-next-messages round-id guest 1)))
+   (step "play one turn"
+         (let [{:keys [round creator guest]} @context]
+           (play-and-check round {creator "rock" guest "paper"} "0|1;rock|paper")))
+   (step "play to guest victory"
+         (let [{:keys [round creator guest]} @context]
+          (play-and-check round {creator "rock" guest "rock"} "0|1;rock|rock")
+           (play-and-check round {creator "spock" guest "rock"} "1|1;spock|rock")
+           (play-and-check round {creator "spock" guest "paper"} "1|2;spock|paper")
+           (play-and-check round {creator "spock" guest "paper"} "1|3;spock|paper")
+           (play-and-check round {creator "spock" guest "paper"} "1|4;spock|paper")))
+   (step "play victory move"
+         (let [{:keys [round creator guest]} @context]
+           (play round {creator "scissors" guest "spock"})))
+   (step "get final game state"
+         (let [{:keys [round creator guest]} @context
+               creator-state (get-state round creator)
+               guest-state (get-state round guest)]
+           (is (= (creator-state "content") "LOSS BY POINTS"))
+           (is (= (guest-state "content") "WIN BY POINTS"))))))
+
+(comment 
+  (do (integration.story/clean-server)
+      (clojure.test/run-tests 'integration.play-rpsls-test)))

--- a/test/clojure/integration/story.clj
+++ b/test/clojure/integration/story.clj
@@ -12,7 +12,7 @@
 
 (defn ensure-server 
   []
-  (swap! server #(if (nil? %1) (start-server port false) %1)))
+  (swap! server #(or % (start-server port true))))
 
 (defn clean-server
   []

--- a/test/clojure/snow_hall/games/manager_test.clj
+++ b/test/clojure/snow_hall/games/manager_test.clj
@@ -1,15 +1,26 @@
 (ns snow-hall.games.manager-test
   (:require [clojure.test :refer [deftest testing is]]
-            [snow-hall.games.manager :as mgr]))
+            [snow-hall.games.manager :as mgr]
+            [snow-hall.games.game :as game]))
 
 (deftest initial-store-test []
   (testing "The initial store is empty"
     (let [store (mgr/create-store)]
       (is (= store {})))))
 
+(defn create-fake-game
+  []
+  (reify
+    game/Game
+    (get-specs [this] {:name "GameName"
+                       :player-count {:exact 2}})
+    (read-options [this options] nil)
+    (get-player-count [this opions] nil)
+    (create-engine [this options] (throw (UnsupportedOperationException.)))))
+
 (deftest add-game-test []
   (testing "Adding a game to the store"
     (let [store (mgr/create-store)
-          new-game {:name "GameName" :player-count 2}
+          new-game (create-fake-game)
           edited (mgr/add-game store new-game)]
       (is (= edited {"GameName" new-game})))))

--- a/test/clojure/snow_hall/hall/butler_test.clj
+++ b/test/clojure/snow_hall/hall/butler_test.clj
@@ -19,7 +19,7 @@
 (def dummy-game
   (reify game/Game
     (get-specs [this] {:name "g"
-                      :players {:exact 2}})
+                      :player-count {:exact 2}})
     (read-options [this options] {})
     (get-player-count [this options] 3)
     (create-engine [this options] (throw (UnsupportedOperationException.)))))


### PR DESCRIPTION
This allows specifying the number of players, target scores for games, ...

This requires a change of the syntax when creating games. Instead of a simple map, the factory protocol was extended to the whole game.

Note 1: this finally commits the tests for RPSLS.
Note 2: this reviewed the system to run tests, to make it more REPL-friendly.